### PR TITLE
Update qt4_render.py

### DIFF
--- a/ete2/treeview/qt4_render.py
+++ b/ete2/treeview/qt4_render.py
@@ -783,9 +783,9 @@ def render_floatings(n2i, n2f, img, float_layer, float_behind_layer):
             item = n2i[node]
             fb.setParentItem(parent_layer)
 
-            if item.extra_branch_line:
+            try:
                 xtra =  item.extra_branch_line.line().dx()
-            else:
+            except AttributeError:
                 xtra = 0
 
             if img.mode == "c":


### PR DESCRIPTION
When ```tree_style.complete_branch_lines_when_necessary = False``` is specified renderer throws an exception that AttributeError: '_NodeItem' object has no attribute 'extra_branch_line'. This fixes the problem.

Full exception:
```
File "/usr/local/lib/python2.7/site-packages/ete2/coretype/tree.py", line 1359, in render
    units=units, dpi=dpi)
  File "/usr/local/lib/python2.7/site-packages/ete2/treeview/drawer.py", line 107, in render_tree
    tree_item, n2i, n2f = render(t, img)
  File "/usr/local/lib/python2.7/site-packages/ete2/treeview/qt4_render.py", line 320, in render
    render_floatings(n2i, n2f, img, parent.float_layer, parent.float_behind_layer)
  File "/usr/local/lib/python2.7/site-packages/ete2/treeview/qt4_render.py", line 788, in render_floatings
    if item.extra_branch_line:
AttributeError: '_NodeItem' object has no attribute 'extra_branch_line'
```

I've noticed that the guide lines to complete the lines are still drawn even though I specify ```complete_branch_lines_when_necessary``` to be ```False```.