### PR TITLE
get_fuzzy_name_translation in ncbi_taxonomy sqlite update

### DIFF
--- a/ete3/ncbi_taxonomy/ncbiquery.py
+++ b/ete3/ncbi_taxonomy/ncbiquery.py
@@ -136,8 +136,8 @@ class NCBITaxa(object):
         '''
 
 
-        import pysqlite2.dbapi2 as sqlite2
-        _db = sqlite2.connect(self.dbfile)
+        import sqlite3.dbapi2 as dbapi2
+        _db = dbapi2.connect(self.dbfile)
         _db.enable_load_extension(True)
         module_path = os.path.split(os.path.realpath(__file__))[0]
         _db.execute("select load_extension('%s')" % os.path.join(module_path,


### PR DESCRIPTION
pysqlite2 was causing an error on import on my machine.

As far as I can tell this module has been mostly deprecated in favour of sqlit3.

As the rest of the module uses sqlite3 and sqlite3's dbapi2 interface seems to achieve the same task as the original pysqlite2 code I've updated this tiny bit of code to now use sqlite3.dbapi2.
